### PR TITLE
Update eigen url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ ENV PATH ${BASE}/dump/opencv_install:${PATH}
 WORKDIR ${BASE}/dump
 RUN wget -O 3.3.7.tar.gz https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz
 RUN tar -xzf 3.3.7.tar.gz
-RUN mv eigen-eigen-323c052e1731 /usr/local/include/eigen
+RUN mv eigen-3.3.7 /usr/local/include/eigen
 
 # orb-slam2 // resources
 COPY Thirdparty ${BASE}/orbslam2/Thirdparty

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ ENV PATH ${BASE}/dump/opencv_install:${PATH}
 
 # eigen
 WORKDIR ${BASE}/dump
-RUN wget http://bitbucket.org/eigen/eigen/get/3.3.7.tar.gz
+RUN wget https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz
 RUN tar -xzf 3.3.7.tar.gz
 RUN mv eigen-eigen-323c052e1731 /usr/local/include/eigen
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ ENV PATH ${BASE}/dump/opencv_install:${PATH}
 
 # eigen
 WORKDIR ${BASE}/dump
-RUN wget https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz
+RUN wget -O 3.3.7.tar.gz https://gitlab.com/libeigen/eigen/-/archive/3.3.7/eigen-3.3.7.tar.gz
 RUN tar -xzf 3.3.7.tar.gz
 RUN mv eigen-eigen-323c052e1731 /usr/local/include/eigen
 


### PR DESCRIPTION
Looks like Eigen killed all the bitbucket links in favor of GitLab. This updates the URL in the Dockerfile and creates the proper directory extraction/mv structure.